### PR TITLE
consider the kernel.debug mode

### DIFF
--- a/src/Subscriber/DisableStorefrontErrorHandling.php
+++ b/src/Subscriber/DisableStorefrontErrorHandling.php
@@ -3,12 +3,21 @@
 namespace Frosh\DevelopmentHelper\Subscriber;
 
 use Shopware\Core\PlatformRequest;
+use Symfony\Component\DependencyInjection\ParameterBag\ContainerBagInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 class DisableStorefrontErrorHandling implements EventSubscriberInterface
 {
+    /** @var ContainerBagInterface */
+    private $containerBag;
+
+    public function __construct(ContainerBagInterface $containerBag)
+    {
+        $this->containerBag = $containerBag;
+    }
+
     public static function getSubscribedEvents()
     {
         return [
@@ -18,6 +27,11 @@ class DisableStorefrontErrorHandling implements EventSubscriberInterface
 
     public function disableFrontendErrorHandling(ExceptionEvent $event)
     {
+        //if we are in dev mode, we will see exceptions
+        if ($this->containerBag->all()['kernel.debug']) {
+            return;
+        }
+
         if ($event->getRequest()->attributes->has(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT)) {
             $event->stopPropagation();
         }


### PR DESCRIPTION
Currently, if we are in debug mode, this means, Server Environment is set to APP_DEBUG=true. FroshDevelomentHelper hides Exception trace with this.

![Bildschirmfoto 2021-01-21 um 22 18 59](https://user-images.githubusercontent.com/907458/105415553-2e067b00-5c39-11eb-8524-48e2e96ce30e.png)

With this fix, we consider the configuration and get a nice exception trace.

![Bildschirmfoto 2021-01-21 um 22 18 33](https://user-images.githubusercontent.com/907458/105415974-c43aa100-5c39-11eb-8916-c2f1a23d3840.png)
