### PR TITLE
Add breaking block to blacklist

### DIFF
--- a/src/Component/Twig/NodeVisitor/BlogCommentNodeVisitor.php
+++ b/src/Component/Twig/NodeVisitor/BlogCommentNodeVisitor.php
@@ -18,7 +18,8 @@ class BlogCommentNodeVisitor extends AbstractNodeVisitor
         'head_meta_tags',
         'layout_head_title',
         'page_product_detail_buy_form_action',
-        'base_body_classes'
+        'base_body_classes',
+        'page_checkout_additional'
     ];
 
     /**


### PR DESCRIPTION
Add `page_checkout_additional` to blacklist as it breaks the checkout summary layout. Fixes #26 