### PR TITLE
fix potentially missing slash

### DIFF
--- a/src/Component/Generator/Definition/EntityLoader.php
+++ b/src/Component/Generator/Definition/EntityLoader.php
@@ -206,7 +206,7 @@ class EntityLoader
             $loopNamespace = implode('\\', $namespaceSplit) . '\\';
 
             if (isset($prefixes[$loopNamespace])) {
-                return rtrim($prefixes[$loopNamespace][0] . implode('/', array_reverse($suffix)), '/') . '/';
+                return rtrim(rtrim($prefixes[$loopNamespace][0],'/').'/' . implode('/', array_reverse($suffix)), '/') . '/';
             }
 
             $index = count($namespaceSplit)  -1;


### PR DESCRIPTION
in my case, generated Definitions were stored in a folder like "srcContent/xxx".
I just force to add trailing slash (after removing the one present) at the end of folder