### PR TITLE
Add style to excluded keywords

### DIFF
--- a/src/Resources/config/packages/frosh_development_helper.yaml
+++ b/src/Resources/config/packages/frosh_development_helper.yaml
@@ -10,3 +10,4 @@ frosh_development_helper:
       - sitemap
       - srcset
       - title
+      - style


### PR DESCRIPTION
I added the style to the excluded keyword to make documents work again with that plugin running.