### PR TITLE
Add form_create_action to excluded keywords

### DIFF
--- a/src/Resources/config/packages/frosh_development_helper.yaml
+++ b/src/Resources/config/packages/frosh_development_helper.yaml
@@ -11,3 +11,4 @@ frosh_development_helper:
       - srcset
       - title
       - style
+      - form_create_action


### PR DESCRIPTION
Without this change, adding a new address in the checkout sends a POST request to `example.com/checkout/<!-- BLOCK BEGIN address_manager_modal_address_form_create_action (vendor/shopware/storefront/Resources/views/storefront/component/address/address-manager-modal-create-address.html.twig) -->/us/widgets/account/address-manager?type=shipping<!--+BLOCK+END+address_manager_modal_address_form_create_action+-->`