### PR TITLE
Fix Shopware 6.7.6.0 admin

### DIFF
--- a/src/Resources/config/packages/frosh_development_helper.yaml
+++ b/src/Resources/config/packages/frosh_development_helper.yaml
@@ -12,3 +12,6 @@ frosh_development_helper:
       - title
       - style
       - form_create_action
+      - '@Administration/shared/page-loading-screen/page-loading-screen.js'
+      - component_head_analytics_gtag_config
+      - address_manager_modal_address_form_create


### PR DESCRIPTION
Add an include comment to exclude for Shopware 6.7.6.0 compatibility and some other blocks to exclude that in our stores creates some issues. If you want, I can remove the last two lines.